### PR TITLE
Fix bug in comments extraction from ports/parameters

### DIFF
--- a/src/sv_simpleparser/_hdl.py
+++ b/src/sv_simpleparser/_hdl.py
@@ -29,7 +29,7 @@
 import logging
 import re
 
-from pygments.lexer import ExtendedRegexLexer, LexerContext, bygroups, include, words
+from pygments.lexer import ExtendedRegexLexer, LexerContext, bygroups, default, include, words
 from pygments.token import (
     Comment,
     Error,
@@ -737,7 +737,7 @@ class SystemVerilogLexer(ExtendedRegexLexer):
             keywords,  # The keyword module can be followed by the keywords static|automatic
             include("comments"),
             (r"\$?[a-zA-Z_]\w*", Module.ModuleName, ("#pop", "module_header")),
-            (r".", Token.Error, "#pop"),
+            default("#pop"),
         ],
         "module_header": [
             include("comments"),
@@ -754,7 +754,7 @@ class SystemVerilogLexer(ExtendedRegexLexer):
             punctuation,
         ],
         "port_declaration": [
-            include("comments"),
+            include("port_comments"),
             (port_types, Port.PortType),
             (r"((\[[^]]+\])+)", Port.PortWidth),  # Match one or more brackets, indicating the port width
             # port declaration ends with a ;, a ); or with the start of another port declaration
@@ -767,11 +767,11 @@ class SystemVerilogLexer(ExtendedRegexLexer):
             (r"\)\s*;", Module.HeaderEnd, "#pop:2"),
             (r",", Punctuation),
             (r";", Punctuation, "#pop"),
-            (r".", Token.Error, "#pop"),
+            default("#pop"),
         ],
         "param_declaration": [
             (r"`\w+\s*\(.*?\)", Module.Other),
-            include("comments"),
+            include("param_comments"),
             (port_types, Module.Param.ParamType),
             # Match one or more brackets, indicating the param width
             (r"((\[[^]]+\])+)", Module.Param.ParamWidth),
@@ -783,13 +783,25 @@ class SystemVerilogLexer(ExtendedRegexLexer):
             (r"\)\s*;", Module.HeaderEnd, "#pop:2"),
             (r",", Punctuation),
             (r";", Punctuation, "#pop"),
-            (r".", Token.Error, "#pop"),
+            default("#pop"),
         ],
         "comments": [
             (r"\s+", Whitespace),
             (r"(\\)(\n)", bygroups(String.Escape, Whitespace)),  # line continuation
             (r"/(\\\n)?/(\n|(.|\n)*?[^\\]\n)", Comment.Single),
             (r"/(\\\n)?[*](.|\n)*?[*](\\\n)?/", Comment.Multiline),
+        ],
+        "port_comments": [
+            (r"\s+", Whitespace),
+            (r"(\\)(\n)", bygroups(String.Escape, Whitespace)),  # line continuation
+            (r"/(\\\n)?/(\n|(.|\n)*?[^\\]\n)", Module.Port.Comment),
+            (r"/(\\\n)?[*](.|\n)*?[*](\\\n)?/", Module.Port.Comment),
+        ],
+        "param_comments": [
+            (r"\s+", Whitespace),
+            (r"(\\)(\n)", bygroups(String.Escape, Whitespace)),  # line continuation
+            (r"/(\\\n)?/(\n|(.|\n)*?[^\\]\n)", Module.Param.Comment),
+            (r"/(\\\n)?[*](.|\n)*?[*](\\\n)?/", Module.Param.Comment),
         ],
         # "comments": [
         #    (r"\s+", Whitespace),

--- a/tests/refdata/tests.test_parser/test_examples/adder.sv/overview.txt
+++ b/tests/refdata/tests.test_parser/test_examples/adder.sv/overview.txt
@@ -18,7 +18,11 @@
           "direction": "input",
           "ptype": "unsigned",
           "name": "A",
-          "width": "[DATA_WIDTH-1:0]"
+          "width": "[DATA_WIDTH-1:0]",
+          "comment": [
+            "// This is a test\n",
+            "// This is another test\n"
+          ]
         },
         {
           "direction": "input",

--- a/tests/refdata/tests.test_parser/test_examples/encoder_using_case.sv/overview.txt
+++ b/tests/refdata/tests.test_parser/test_examples/encoder_using_case.sv/overview.txt
@@ -8,18 +8,27 @@
           "direction": "output",
           "ptype": "reg",
           "name": "binary_out",
-          "width": "[3:0]"
+          "width": "[3:0]",
+          "comment": [
+            "//  4 bit binary Output\n"
+          ]
         },
         {
           "direction": "input",
           "ptype": "wire",
           "name": "encoder_in",
-          "width": "[15:0]"
+          "width": "[15:0]",
+          "comment": [
+            "//  16-bit Input\n"
+          ]
         },
         {
           "direction": "input",
           "ptype": "wire",
-          "name": "enable"
+          "name": "enable",
+          "comment": [
+            "//  Enable for the encoder\n"
+          ]
         }
       ]
     }

--- a/tests/refdata/tests.test_parser/test_examples/param_module.sv/overview.txt
+++ b/tests/refdata/tests.test_parser/test_examples/param_module.sv/overview.txt
@@ -5,7 +5,10 @@
       "name": "param_module",
       "params": [
         {
-          "name": "WIDTH"
+          "name": "WIDTH",
+          "comment": [
+            "// Width of the input data\n"
+          ]
         },
         {
           "name": "DEPTH"
@@ -28,13 +31,19 @@
         {
           "direction": "input",
           "ptype": "wire",
-          "name": "rst_n"
+          "name": "rst_n",
+          "comment": [
+            "// active-low reset\n"
+          ]
         },
         {
           "direction": "input",
           "ptype": "wire",
           "name": "data_in",
-          "width": "[WIDTH-1:0]"
+          "width": "[WIDTH-1:0]",
+          "comment": [
+            "// Input data\n"
+          ]
         },
         {
           "direction": "output",

--- a/tests/refdata/tests.test_parser/test_examples/up_down_counter.sv/overview.txt
+++ b/tests/refdata/tests.test_parser/test_examples/up_down_counter.sv/overview.txt
@@ -8,22 +8,34 @@
           "direction": "output",
           "ptype": "reg",
           "name": "out",
-          "width": "[7:0]"
+          "width": "[7:0]",
+          "comment": [
+            "// Output of the counter\n"
+          ]
         },
         {
           "direction": "input",
           "ptype": "wire",
-          "name": "up_down"
+          "name": "up_down",
+          "comment": [
+            "// up_down control for counter\n"
+          ]
         },
         {
           "direction": "input",
           "ptype": "wire",
-          "name": "clk"
+          "name": "clk",
+          "comment": [
+            "// clock input\n"
+          ]
         },
         {
           "direction": "input",
           "ptype": "wire",
-          "name": "reset"
+          "name": "reset",
+          "comment": [
+            "// reset input\n"
+          ]
         }
       ]
     }

--- a/tests/svfiles_examples/adder.sv
+++ b/tests/svfiles_examples/adder.sv
@@ -7,6 +7,7 @@ module adder #(
   parameter integer DATA_WIDTH, TEST = 4
 ) (
   input  logic unsigned [DATA_WIDTH-1:0] A, // This is a test
+                                            // This is another test
   input  logic unsigned [DATA_WIDTH-1:0] B,
   output logic unsigned [DATA_WIDTH:0]   X
 );

--- a/tests/svfiles_examples/param_module.sv
+++ b/tests/svfiles_examples/param_module.sv
@@ -4,14 +4,14 @@
 module param_module
 import test_pack::*;
 #(
-    parameter WIDTH = 8,
+    parameter WIDTH = 8, // Width of the input data
     parameter DEPTH = 4,
     parameter [7:0] INIT_VAL = 8'hFF,
     parameter logic ENABLE_FEATURE = 1'b1
 ) (
     input wire clk,
     input wire rst_n,  // active-low reset
-    input wire [WIDTH-1:0] data_in,
+    input wire [WIDTH-1:0] data_in, // Input data
     output reg [WIDTH-1:0] data_out,
     inout wire [DEPTH-1:0] bidir_bus
 );

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -53,7 +53,13 @@ def test_adder(examples):
                     Param(ptype="integer", name="TEST", width=None, comment=None),
                 ),
                 ports=(
-                    Port(direction="input", ptype="unsigned", name="A", width="[DATA_WIDTH-1:0]", comment=None),
+                    Port(
+                        direction="input",
+                        ptype="unsigned",
+                        name="A",
+                        width="[DATA_WIDTH-1:0]",
+                        comment=["// This is a test\n", "// This is another test\n"],
+                    ),
                     Port(direction="input", ptype="unsigned", name="B", width="[DATA_WIDTH-1:0]", comment=None),
                     Port(direction="output", ptype="unsigned", name="X", width="[DATA_WIDTH:0]", comment=None),
                 ),
@@ -73,15 +79,21 @@ def test_param_module(examples):
             Module(
                 name="param_module",
                 params=(
-                    Param(ptype=None, name="WIDTH", width=None, comment=None),
+                    Param(ptype=None, name="WIDTH", width=None, comment=["// Width of the input data\n"]),
                     Param(ptype=None, name="DEPTH", width=None, comment=None),
                     Param(ptype=None, name="INIT_VAL", width="[7:0]", comment=None),
                     Param(ptype="logic", name="ENABLE_FEATURE", width=None, comment=None),
                 ),
                 ports=(
                     Port(direction="input", ptype="wire", name="clk", width=None, comment=None),
-                    Port(direction="input", ptype="wire", name="rst_n", width=None, comment=None),
-                    Port(direction="input", ptype="wire", name="data_in", width="[WIDTH-1:0]", comment=None),
+                    Port(direction="input", ptype="wire", name="rst_n", width=None, comment=["// active-low reset\n"]),
+                    Port(
+                        direction="input",
+                        ptype="wire",
+                        name="data_in",
+                        width="[WIDTH-1:0]",
+                        comment=["// Input data\n"],
+                    ),
                     Port(direction="output", ptype="reg", name="data_out", width="[WIDTH-1:0]", comment=None),
                     Port(direction="inout", ptype="wire", name="bidir_bus", width="[DEPTH-1:0]", comment=None),
                 ),


### PR DESCRIPTION
- Fixes bug where comments were not being extracted from the ports and parameters declarations.
- Update tests to include comments.